### PR TITLE
fix(eval): return empty map on empty redeemer report

### DIFF
--- a/testgen-hs/Evaluation.hs
+++ b/testgen-hs/Evaluation.hs
@@ -110,7 +110,7 @@ eval'Conway pparams tx utxo epochInfo systemStart =
             (purpose, exUnits) : _ ->
               Map.singleton purpose (Right exUnits)
             [] ->
-              error "Empty redeemer report from evalTxExUnits"
+              Map.empty
       where
         (failures, successes) = Map.foldrWithKey groupReports (Map.empty, Map.empty) report
 


### PR DESCRIPTION
Now we handle empty redeemer report not as an error and return an empty evaluation response.