### PR TITLE
chore(cardano-node): update to 10.6.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "cardano-node": {
       "flake": false,
       "locked": {
-        "lastModified": 1770822424,
-        "narHash": "sha256-zyrBw3yn69y3n0c6U0MDvezYC3GHbjJ3yJmhM4vMtUk=",
+        "lastModified": 1774886169,
+        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0d697f14ee10a775f08c60e3839becc9131dca75",
+        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.2",
+        "ref": "10.6.3",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     cardano-node = {
-      url = "github:IntersectMBO/cardano-node/10.6.2";
+      url = "github:IntersectMBO/cardano-node/10.6.3";
       flake = false; # otherwise, +2k dependencies we don’t really use
     };
     nix-bundle-exe = {

--- a/nix/internal.nix
+++ b/nix/internal.nix
@@ -237,8 +237,9 @@ in rec {
             printf '%s\n' "$_new" > "$PWD/cabal.project"
           fi
 
-          _chap_marker="$CABAL_DIR/.chap-store-path"
+          _chap_marker="$CABAL_DIR/.chap-index-id"
           if [ ! -e "$_chap_marker" ] || [ "$(cat "$_chap_marker")" != "${chap-store-path}" ]; then
+            rm -rf "$CABAL_DIR/packages/cardano-haskell-packages"
             mkdir -p "$CABAL_DIR/packages/cardano-haskell-packages"
             cabal update cardano-haskell-packages 2>/dev/null
             printf '%s' '${chap-store-path}' >"$_chap_marker"
@@ -302,10 +303,14 @@ in rec {
             printf '%s\n' "$_new" > "$PRJ_ROOT/cabal.project"
           fi
           # Re-index the local CHaP only when the underlying Nix store
-          # path changes (i.e. after a flake.lock update).  A marker
+          # path changes (i.e. after a flake.lock update). A marker
           # file records the store path that was last indexed.
-          _chap_marker="$CABAL_DIR/.chap-store-path"
+          _chap_marker="$CABAL_DIR/.chap-index-id"
           if [ ! -e "$_chap_marker" ] || [ "$(cat "$_chap_marker")" != "${chap-store-path}" ]; then
+            # We delete the old cache first because cabal's incremental
+            # update does not always rebuild the uncompressed index tar
+            # from the new tar.gz, leaving a stale 01-index.tar behind.
+            rm -rf "$CABAL_DIR/packages/cardano-haskell-packages"
             mkdir -p "$CABAL_DIR/packages/cardano-haskell-packages"
             cabal update cardano-haskell-packages 2>/dev/null
             printf '%s' '${chap-store-path}' >"$_chap_marker"

--- a/testgen-hs/testgen-hs.cabal
+++ b/testgen-hs/testgen-hs.cabal
@@ -5,7 +5,7 @@ synopsis:
   CBOR test case generator and deserializer for cross-checking other implementations
 
 -- Version tracks cardano-node, adding a patch segment:
-version:       10.6.2.0
+version:       10.6.3.0
 
 executable testgen-hs
   main-is:            Main.hs


### PR DESCRIPTION
## Context

- Update to [cardano-node/releases/tag/10.6.3](https://github.com/IntersectMBO/cardano-node/releases/tag/10.6.3).

- I changed how the devshell entry updates its index of CHaP – we need an additional cache invalidation, but it only happens once after updating `cardano-node`.

## Result

```
❯ cabal run testgen-hs -- --help | head -4
Usage: testgen-hs COMMAND [-v|--version]

  testgen-hs 10.6.3.0 - CBOR test case generator and deserializer for
  cross-checking other implementations
```