### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,6 @@ jobs:
             result-archive-aarch64-darwin \
             .#hydraJobs.testgen-hs.aarch64-darwin
 
-          nix build -L --builders '' --max-jobs 0 --out-link \
-            result-archive-x86_64-darwin \
-            .#hydraJobs.testgen-hs.x86_64-darwin
-
           find -L result-*
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
@@ -53,6 +49,5 @@ jobs:
           files: |
             result-archive-x86_64-linux/*.tar.bz2
             result-archive-aarch64-linux/*.tar.bz2
-            result-archive-x86_64-darwin/*.tar.bz2
             result-archive-aarch64-darwin/*.tar.bz2
             result-archive-x86_64-windows/*.zip

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -24,7 +24,6 @@ jobs:
           nix build --builders "" --max-jobs 0 .#hydraJobs.testgen-hs.x86_64-linux   && cp result/testgen-hs-*.* .
           nix build --builders "" --max-jobs 0 .#hydraJobs.testgen-hs.aarch64-linux  && cp result/testgen-hs-*.* .
           nix build --builders "" --max-jobs 0 .#hydraJobs.testgen-hs.x86_64-windows && cp result/testgen-hs-*.* .
-          nix build --builders "" --max-jobs 0 .#hydraJobs.testgen-hs.x86_64-darwin  && cp result/testgen-hs-*.* .
           nix build --builders "" --max-jobs 0 .#hydraJobs.testgen-hs.aarch64-darwin && cp result/testgen-hs-*.* .
       - name: Read Version
         run: |
@@ -37,12 +36,6 @@ jobs:
         with:
           name: testgen-hs-${{ env.version }}-aarch64-darwin.tar.bz2
           path: testgen-hs-${{ env.version }}-aarch64-darwin.tar.bz2
-          if-no-files-found: error
-      - name: Upload Artifact (x86_64-darwin)
-        uses: actions/upload-artifact@v4
-        with:
-          name: testgen-hs-${{ env.version }}-x86_64-darwin.tar.bz2
-          path: testgen-hs-${{ env.version }}-x86_64-darwin.tar.bz2
           if-no-files-found: error
       - name: Upload Artifact (x86_64-linux)
         uses: actions/upload-artifact@v4

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
           targetSystem: import ./nix/internal.nix {inherit inputs targetSystem;}
         );
 
-      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
       perSystem = {system, ...}: let
         internal = inputs.self.internal.${system};
       in {


### PR DESCRIPTION
- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

Consider this a suggestion — our primary objective is to reduce load on CI.